### PR TITLE
Mjcross

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Check the readme of each driver in its corresponding folder.
 This package includes a graphics library, based on [Adafruit-GFX-Library](https://github.com/adafruit/Adafruit-GFX-Library).
 It supports drawing basic shapes, characters and using custom fonts.
 
+Note that the `gfx.h` header contains a convenience macro `GFX_RGB565(R, G, B)` to create a 16-bit 'rgb565' colour value from individual 8-bit components.
+
 ### GFX Framebuffer
 By default, the GFX library writes pixels directly to the screen. If desired, an internal framebuffer can be used (which is recomended in cases where speed is desired). The framebuffer is created using `GFX_createFramebuf()`, which automatically tells the library to write to the framebuffer. The buffer can then be pushed to the screen by calling `GFX_flush()`. If needed, the buffer can be destroyed by calling `GFX_destroyFramebuf()`. Doing so will revert to writing pixels directly to the screen.
 ## GFX Library Reference

--- a/gfx/gfx.h
+++ b/gfx/gfx.h
@@ -5,7 +5,7 @@
 #include "gfxfont.h"
 
 // convert 8 bit r, g, b values to 16 bit colour (rgb565 format) 
-#define GFX_RGB565(R, G, B) ((uint16_t)((R & 0b11111000) << 8) | ((G & 0b11111100) << 3) | (B >> 3))
+#define GFX_RGB565(R, G, B) ((uint16_t)(((R) & 0b11111000) << 8) | (((G) & 0b11111100) << 3) | ((B) >> 3))
 
 void GFX_createFramebuf();
 void GFX_destroyFramebuf();

--- a/gfx/gfx.h
+++ b/gfx/gfx.h
@@ -4,6 +4,9 @@
 #include "pico/stdlib.h"
 #include "gfxfont.h"
 
+// convert 8 bit r, g, b values to 16 bit colour (rgb565 format) 
+#define GFX_RGB565(R, G, B) ((uint16_t)((R & 0b11111000) << 8) | ((G & 0b11111100) << 3) | (B >> 3))
+
 void GFX_createFramebuf();
 void GFX_destroyFramebuf();
 


### PR DESCRIPTION
Thanks very much for your drivers: they work well with a RPi Pico and a cheap ILI9341 display.
I don't know if you agree, but I find 16-bit colour values a bit inconvenient to work with directly - so I added a simple macro to `gfx.h` for that... 