### PR TITLE
Updated to include extern C when compiled by CPP

### DIFF
--- a/gfx/gfx.h
+++ b/gfx/gfx.h
@@ -1,6 +1,10 @@
 #ifndef gfx_H
 #define gfx_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "pico/stdlib.h"
 #include "gfxfont.h"
 
@@ -41,4 +45,8 @@ void GFX_scrollUp(int n);
 uint GFX_getWidth();
 uint GFX_getHeight();
 
+#ifdef __cplusplus
+}
 #endif
+
+#endif //gfx_H

--- a/ili9341/ili9341.h
+++ b/ili9341/ili9341.h
@@ -1,5 +1,10 @@
 #ifndef ILI9341_H
 #define ILI9341_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "pico/stdlib.h"
 #include "hardware/spi.h"
 
@@ -95,4 +100,8 @@ void LCD_setRotation(uint8_t m);
 void LCD_WritePixel(int x, int y, uint16_t col);
 void LCD_WriteBitmap(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint16_t *bitmap);
 
+#ifdef __cplusplus
+}
 #endif
+
+#endif //ILI9341_H

--- a/st7735/st7735.h
+++ b/st7735/st7735.h
@@ -3,6 +3,10 @@
 #include "pico/stdlib.h"
 #include "hardware/spi.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Pins
 #define ST7735_CS PICO_DEFAULT_SPI_CSN_PIN
 #define ST7735_RST 16
@@ -106,4 +110,9 @@ void LCD_setRotation(uint8_t m);
 
 void LCD_WriteBitmap(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint16_t *bitmap);
 void LCD_WritePixel(int x, int y, uint16_t col);
+
+#ifdef __cplusplus
+}
 #endif
+
+#endif //ST7735_H

--- a/st7789/st7789.h
+++ b/st7789/st7789.h
@@ -1,5 +1,10 @@
 #ifndef ST7789_H
 #define ST7789_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "pico/stdlib.h"
 #include "hardware/spi.h"
 
@@ -64,4 +69,8 @@ void LCD_setRotation(uint8_t m);
 void LCD_WritePixel(int x, int y, uint16_t col);
 void LCD_WriteBitmap(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint16_t *bitmap);
 
+#ifdef __cplusplus
+}
 #endif
+
+#endif //ST7789_H


### PR DESCRIPTION
The compilation would fail in the event that a client program is using C++ rather than C.

This change includes extern "C" wraps around the appropriate headers in the event that it is being compiled by a C++ compiler.